### PR TITLE
how to fix a misused meshkit logger

### DIFF
--- a/istio/sample_apps.go
+++ b/istio/sample_apps.go
@@ -129,10 +129,10 @@ func (istio *Istio) LoadNamespaceToMesh(namespace string, remove bool) error {
 	// The LoadNamespaceToMesh() function is called in istio/istio.go and the
 	// error returned by this is logged through the meshkit logger
 	//
-	// The below function returns Go's built in error type but we can't
+	// The below function returns Go's built-in error type but we can't
 	// log that using meshkit logger.
 	//
-	// Thus, the error returned in the below line should be wrapped into a meshkit
+	// Thus, the error returned in the line below should be wrapped into a meshkit
 	// error first and then returned.
 	_, err = istio.KubeClient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
 	if err != nil {

--- a/istio/sample_apps.go
+++ b/istio/sample_apps.go
@@ -124,9 +124,23 @@ func (istio *Istio) LoadNamespaceToMesh(namespace string, remove bool) error {
 		delete(ns.ObjectMeta.Labels, "istio-injection")
 	}
 
+	// How to use meshkit errors which are logged using meshkit logger
+	//
+	// The LoadNamespaceToMesh() function is called in istio/istio.go and the
+	// error returned by this is logged through the meshkit logger
+	//
+	// The below function returns Go's built in error type but we can't
+	// log that using meshkit logger.
+	//
+	// Thus, the error returned in the below line should be wrapped into a meshkit
+	// error first and then returned.
 	_, err = istio.KubeClient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
 	if err != nil {
-		return err
+		// Don't do this ❌
+		// return err
+
+		// Do this ✔
+		return ErrLoadNamespace(err, namespace)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudrakshpareek3601@gmail.com>

**Description**

This PR fixes an instance of misused meshkit logger

**Notes for Reviewers**
**We need to replace this everywhere to prevent frequent panics which are hiding in plain sight but are noticed only when an error actually occurs.**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

