### PR TITLE
Fixed failing tests due to use of wrong instance of adapter during test

### DIFF
--- a/istio/istio_test.go
+++ b/istio/istio_test.go
@@ -386,10 +386,7 @@ func TestIstio_ApplyOperation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			istio := &Istio{
-				Adapter: tt.fields.Adapter,
-			}
-			if err := istio.ApplyOperation(tt.args.ctx, tt.args.opReq); (err != nil) != tt.wantErr {
+			if err := tt.fields.Adapter.ApplyOperation(tt.args.ctx, tt.args.opReq); (err != nil) != tt.wantErr {
 				t.Errorf("Istio.ApplyOperation() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: ashish <ashishjaitiwari15112000@gmail.com>

**Description**

This PR fixes #278 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

