### PR TITLE
Meshery Community image updated in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 <p style="text-align:center;" align="center">
   <a href="https://meshery.io">
     <picture align="center">
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/meshery/meshery-istio/master/img/readme/meshery-logo-dark-text-side.svg"  width="70%" align="center" style="margin-bottom:20px;">readme/community.svg
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/meshery/meshery-istio/master/img/readme/meshery-logo-dark-text-side.svg"  width="70%" align="center" style="margin-bottom:20px;">
       <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/meshery/meshery-istio/master/img/readme/meshery-logo-light-text-side.svg" width="70%" align="center" style="margin-bottom:20px;">
       <img alt="Shows an illustrated light mode meshery logo in light color mode and a dark mode meshery logo dark color mode." src="https://raw.githubusercontent.com/meshery/meshery-istio/master/img/readme/meshery-logo-light-text-side.svg" width="70%" align="center" style="margin-bottom:20px;">
     </picture>
-  </a><br /><br />
+  </a>
+  <a href="https://meshery.io/community"><img alt="Meshery Community" src="img/readme/community.svg" width="25%" align="left" /></a>
+  <br /><br />
 </p>
  
 # Meshery Adapter for Istio


### PR DESCRIPTION
**Description**

This PR fixes #744

This PR is a fix to update the broken image link to `readme/community.svg` in the README

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<img width="1584" height="344" alt="Screenshot 2025-10-07 223228" src="https://github.com/user-attachments/assets/de385743-8166-485f-ab04-a35174fc18fe" />
<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

