### PR TITLE
[meshery-istio] ci: globally disable ST1005 staticcheck lint rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 linters-settings:
+  staticcheck:
+    checks: ["all", "-ST1005"]
   gci:
     enabled: true
     max-len: 120
@@ -49,6 +51,7 @@ linters:
     - unused
     - cyclop
     - scopelint
+    - staticcheck
   exclude-rules:
     - testpackage
 


### PR DESCRIPTION
## **Description**

This PR updates the `.golangci.yml` configuration for the Meshery Istio adapter to globally and permanently disable the **ST1005** (lowercase error strings) staticcheck rule. This change ensures consistency with the linting strategy across the Meshery ecosystem.

Fixes meshery/meshery#16867

## **Notes for Reviewers**

- Modified `.golangci.yml` to exclude ST1005 from staticcheck checks.
- Verified that the `staticcheck` linter is enabled in the linter list.
- Standardizing error string formatting rules as discussed in the main issue.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.
